### PR TITLE
Fix symfony dispatcher to use the RouteInfo class

### DIFF
--- a/app/Dispatcher/SymfonyDispatcher.php
+++ b/app/Dispatcher/SymfonyDispatcher.php
@@ -2,31 +2,39 @@
 
 namespace App\Dispatcher;
 
-use Penny\Exception\MethodNotAllowed;
-use Penny\Exception\RouteNotFound;
+use FastRoute\Dispatcher;
+use Penny\Exception\MethodNotAllowedException;
+use Penny\Exception\RouteNotFoundException;
+use Penny\Route\RouteInfo;
 use Symfony\Component\HttpFoundation\Request;
 
 class SymfonyDispatcher
 {
     private $router;
+    private $container;
 
-    public function __construct($router)
+    public function __construct($router, $container)
     {
         $this->router = $router;
+        $this->container = $container;
     }
 
     public function __invoke(Request $request)
     {
         $routeInfo = $this->router->dispatch($request->getMethod(), $request->getPathInfo());
         switch ($routeInfo[0]) {
-            case \FastRoute\Dispatcher::NOT_FOUND:
-                throw new RouteNotFound;
+            case Dispatcher::NOT_FOUND:
+                throw new RouteNotFoundException;
                 break;
-            case \FastRoute\Dispatcher::METHOD_NOT_ALLOWED:
-                throw new MethodNotAllowed;
+            case Dispatcher::METHOD_NOT_ALLOWED:
+                throw new MethodNotAllowedException;
                 break;
-            case \FastRoute\Dispatcher::FOUND:
-                return $routeInfo;
+            case Dispatcher::FOUND:
+                $controller = $this->container->get($routeInfo[1][0]);
+                $eventName = sprintf('%s.%s', strtolower($routeInfo[1][0]), $routeInfo[1][1]);
+
+                return new RouteInfo($eventName, [$controller, $routeInfo[1][1]], $routeInfo[2]);
+
                 break;
             default:
                 throw new \Exception(null, 500);

--- a/config/di.php
+++ b/config/di.php
@@ -10,7 +10,7 @@ return [
     \App\EventListener\DispatcherExceptionListener::class => \DI\object(\App\EventListener\DispatcherExceptionListener::class)
         ->constructor(\DI\get('template')),
     'dispatcher' => \DI\factory(function (\DI\Container $c) {
-        $dispatcher = new \App\Dispatcher\SymfonyDispatcher($c->get('router'));
+        $dispatcher = new \App\Dispatcher\SymfonyDispatcher($c->get('router'), $c);
         return $dispatcher;
     }),
     'session' => \DI\factory(function (\DI\Container $c) {


### PR DESCRIPTION
The bookshelf app was not using `RouteInfo` that has been introduced in `0.6.0` so when [updating to 0.7.0](https://github.com/pennyphp/bookshelf/pull/11/files) the things just broke
